### PR TITLE
Use precompile in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ ADD docker/nginx/sites-enabled/*.conf /etc/nginx/sites-enabled/
 RUN useradd --shell /sbin/nologin nginx && \
     echo "" > /etc/nginx/sites-enabled/default
 
-CMD ["bundle", "exec", "rails", "s"]
+RUN bundle exec rake assets:precompile
 
 EXPOSE 80

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,4 @@
 <div style="text-align:center; margin-top:25%;">
-  <img src="/assets/campfire.png" height="50" alt="ca">
+  <%= image_tag 'campfire.png', :height => '50', :alt => 'ca' %>
   <h1>Hello, world!</h1>
 </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = true
+  config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   app:
     build: .
     working_dir: /usr/src/app
+    command: 'bundle exec rails s'
     volumes:
       - .:/usr/src/app:cached
       - bundle-volume:/usr/src/app/vendor/bundle


### PR DESCRIPTION
- Fix image path with image_tag.
- Fix to serve static file.
- Add precompile in docker build.